### PR TITLE
Composer / HTML message index

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "GForceWeb/WP-Email-Debug",
+  "name": "gforceweb/wp-email-debug",
   "type": "wordpress-plugin",
   "license": "GPL",
   "description": "Never accidentally send users emails from your testing sites again!",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "GForceWeb/WP-Email-Debug",
+  "type": "wordpress-plugin",
+  "license": "GPL",
+  "description": "Never accidentally send users emails from your testing sites again!",
+  "homepage": "https://wordpress.org/plugins/wp-email-debug",
+  "authors": [
+    {
+      "name": "Grant Derepas",
+      "homepage": "https://www.g-force.net"
+    }
+  ],
+  "keywords": [
+    "wordpress"
+  ],
+  "support": {
+    "issues": "https://github.com/GForceWeb/WP-Email-Debug/issues"
+  },
+  "require": {
+    "php": ">=5.3",
+    "composer/installers": "~1.0"
+  }
+}

--- a/wp-email-debug.php
+++ b/wp-email-debug.php
@@ -85,13 +85,40 @@ if (!class_exists('WPMailDebugger')):
 
     public static function filterEmail( $args )
     {
-      $to_address = get_option('WPMDBUG_email', get_bloginfo('admin_email'));
-      $original = $args['to'];
+      $isHtml  = isset( $args['html'] );
+      $prefix  = '';
+      $message = $isHtml ? $args['html'] : $args['message'];
 
-      if (self::contextualSwitch()) {
-        $args['to'] = $to_address;
-        $args['subject'] = '[DEBUG] ' . $args['subject'];
-        $args['message'] = "Originally intended to be sent to " . $original . "\n" . $args['message'];
+      if ( self::contextualSwitch() ) {
+
+        // Prefix message
+        $prefix = sprintf(
+          __( 'Originally intended to be sent to %s', 'wp-email-debug' ),
+          $args['to']
+        );
+
+        if ( ! empty( $prefix ) ) {
+          $prefix = $prefix . ( $isHtml ? '<br>' : '\n' );
+        }
+
+        // Update email to address
+        $args['to'] = get_option( 'WPMDBUG_email', get_bloginfo( 'admin_email' ) );
+
+        // Update email subject
+        $args['subject'] = sprintf(
+          __( '[DEBUG] %s', 'wp-email-debug' ),
+          $args['subject']
+        );
+
+      }
+
+      $message = $prefix . $message;
+
+      if ( $isHtml ) {
+        $args['html'] = $message;
+      }
+      else {
+        $args['message'] = $message;
       }
 
       return $args;


### PR DESCRIPTION
Hi,

This PR includes three things:
- Check first for $args['html'] and, if not present, fallback to $args['message']
  This is useful when using this plugin with wpMandrill.
- When a message is in HTML, use <br> has spacer instead of \n;
- Added a composer.json file to your plugin so that can be included using Composer;
